### PR TITLE
Use null instead of dummy rooms.

### DIFF
--- a/zuul/notsobad/Exit.java
+++ b/zuul/notsobad/Exit.java
@@ -61,7 +61,7 @@ class Exit {
      * Creates an 'empty' Exit object leading to a dummy room
      */
     public Exit() {
-        this(new Room(), Directions.EMPTY);
+        this(null, Directions.EMPTY);
     }
 
     public boolean isEmpty() {

--- a/zuul/notsobad/Game.java
+++ b/zuul/notsobad/Game.java
@@ -36,13 +36,12 @@ public class Game {
      * Create the game and initialise its internal map.
      */
     public Game() {
-        player = new Player();
         map = new GameMap();
         config = new Config();
         parser = new Parser(config.getAliases());
         isRunning = true;
         createRooms();
-
+        player = new Player(map.getStartRoom());
     }
 
     /**
@@ -82,7 +81,6 @@ public class Game {
 
 
         map.setStartRoom(map.getRoomByName("outside"));
-        player.setCurrentLocation(map.getStartRoom());// start game outside
     }
 
     /**

--- a/zuul/notsobad/GameMap.java
+++ b/zuul/notsobad/GameMap.java
@@ -67,7 +67,7 @@ class GameMap {
                 return currentRoom;
             }
         }
-        return new Room();
+        return null;
     }
 
     public Room getselectedRoom() {

--- a/zuul/notsobad/Gate.java
+++ b/zuul/notsobad/Gate.java
@@ -65,7 +65,7 @@ class Gate {
      * If the parameter is neither it returns a dummy-room
      *
      * @param room the room whose counterpart should be returned
-     * @return the counterpart if able, else dummy-room
+     * @return the counterpart if able, otherwise null
      */
     public Room getOther(final Room room) {
         if (room.equals(end)) {
@@ -74,7 +74,7 @@ class Gate {
             if (room.equals(start)) {
                 return end;
             }
-            return new Room();
+            return null;
         }
     }
 

--- a/zuul/notsobad/Player.java
+++ b/zuul/notsobad/Player.java
@@ -6,10 +6,10 @@ class Player extends Character {
     private Room currentLocation;
     private ArrayList<StoryEvent> registeredEvents;
 
-    public Player() {
+    public Player(Room currentLocation) {
         super();
+        this.currentLocation = currentLocation;
         registeredEvents = new ArrayList<StoryEvent>();
-        currentLocation = new Room();
     }
 
     public Room getCurrentLocation() {

--- a/zuul/notsobad/Room.java
+++ b/zuul/notsobad/Room.java
@@ -46,13 +46,6 @@ class Room {
         this.registeredEvents = new ArrayList<StoryEvent>();
     }
 
-    /**
-     * Creates a dummy-Room, to avoid nullpointers
-     */
-    public Room() {
-        this("Dummy-Room", "You should never encounter this");
-    }
-
     public String getDescription() {
         return description;
     }


### PR DESCRIPTION
There shouldn't be a need for dummy rooms with proper error handling.
Returning a dummy room when searching for non-existing rooms also caused the
insertion of new rooms into the map to fail.
